### PR TITLE
Dev/loadmods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ A Quest/Android specific modloader for Beat Saber.
 This is a [LibProxyMain](https://github.com/sc2ad/LibMainLoader) compatible modloader. Thus, it should be placed at: `/sdcard/ModData/<APP ID>/Modloader/libsl2.so`.
 This modloader has several call in points. It performs a topological sort of all depenents that need to be loaded and loads them in turn. `libs` are loaded very early, on `modloader_load`, while `early_mods` are also constructed at this time. `early_mods` have their `load` function called on them after `il2cpp_init`, which is hooked via [Flamingo](https://github.com/sc2ad/Flamingo) to allow us to perform loading at a sufficiently late time. early mods will also have a function named `late_load` called when mods are constructed, but more on that in the next paragraph.
 
-`mods` will be constructed when the libunity.so method `UnityPostLoadApplication` is called. This method is hooked with flamingo through an xref trace through JNI_Onload all the way to that method. After mods are opened and constructed, early mods get their late_load method called, after which mods will get their load and late_load methods called.
+`mods` will be constructed when the libunity.so method `UnityPostLoadApplication` is called. This method is hooked with flamingo through an xref trace through JNI_Onload all the way to that method. After mods are opened and constructed, early mods get their late_load method called, after which mods will get their late_load method called.
 
 Here is a table containing what gets opened and called when.
  - `dlopen` means the .so file will be opened at that time.
  - `setup` means the setup method which fills the mod info is called at that point.
  - `load` means the load method is called at that point
- - `late_load` means that that is when late_load is invoked.
+ - `late_load` means the late_load method is called at that point.
 
-|                          | Lib      | Early Mod        | Mod                                    |
-|--------------------------|----------|------------------|----------------------------------------|
-| app start                | `dlopen` | `dlopen`, `setup`| -                                      |
-| il2cpp_init              | -        | `load`           | -                                      |
-| UnityPostLoadApplication | -        | `late_load`      | `dlopen`, `setup`, `load`, `late_load` |
+|                          | Lib            | Early Mod         | Mod                            |
+|--------------------------|----------------|-------------------|--------------------------------|
+| app start                | `dlopen`       | `dlopen`, `setup` | not yet initialized            |
+| il2cpp_init              | nothing called | `load`            | not yet initialized            |
+| UnityPostLoadApplication | nothing called | `late_load`       | `dlopen`, `setup`, `late_load` |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A Quest/Android specific modloader for Beat Saber.
 This is a [LibProxyMain](https://github.com/sc2ad/LibMainLoader) compatible modloader. Thus, it should be placed at: `/sdcard/ModData/<APP ID>/Modloader/libsl2.so`.
 This modloader has several call in points. It performs a topological sort of all depenents that need to be loaded and loads them in turn. `libs` are loaded very early, on `modloader_load`, while `early_mods` are also constructed at this time. `early_mods` have their `load` function called on them after `il2cpp_init`, which is hooked via [Flamingo](https://github.com/sc2ad/Flamingo) to allow us to perform loading at a sufficiently late time. early mods will also have a function named `late_load` called when mods are constructed, but more on that in the next paragraph.
 
-`mods` will be constructed when the libunity.so method `UnityPostLoadApplication` is called. This method is hooked with flamingo through an xref trace through JNI_Onload all the way to that method. After mods are opened and constructed, early mods get their late_load method called, after which mods will get their late_load method called.
+`mods` will be constructed when the libunity.so method `ClearRoots` is called. This methods deletes all root gameobjects that are made before it before `StartFirstScene` continues on with loading the first game scene. If we ran after StartFirstScene some Awake methods would have run causing problems for certain mods. by running on ClearRoots we get around this and allow modders to create GameObjects and other unity assets at dlopen time, much like how it would happen on PC. This method is hooked with flamingo through an xref trace through JNI_Onload all the way to that method. After mods are opened and constructed, early mods get their late_load method called, after which mods will get their late_load method called.
 
 Here is a table containing what gets opened and called when.
  - `dlopen` means the .so file will be opened at that time.
@@ -24,8 +24,8 @@ Here is a table containing what gets opened and called when.
  - `load` means the load method is called at that point
  - `late_load` means the late_load method is called at that point.
 
-|                          | Lib            | Early Mod         | Mod                            |
-|--------------------------|----------------|-------------------|--------------------------------|
-| app start                | `dlopen`       | `dlopen`, `setup` | not yet initialized            |
-| il2cpp_init              | nothing called | `load`            | not yet initialized            |
-| UnityPostLoadApplication | nothing called | `late_load`       | `dlopen`, `setup`, `late_load` |
+|             | Lib            | Early Mod         | Mod                            |
+|-------------|----------------|-------------------|--------------------------------|
+| app start   | `dlopen`       | `dlopen`, `setup` | not yet initialized            |
+| il2cpp_init | nothing called | `load`            | not yet initialized            |
+| ClearRoots  | nothing called | `late_load`       | `dlopen`, `setup`, `late_load` |

--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ A Quest/Android specific modloader for Beat Saber.
 ## Installation/Usage
 
 This is a [LibProxyMain](https://github.com/sc2ad/LibMainLoader) compatible modloader. Thus, it should be placed at: `/sdcard/ModData/<APP ID>/Modloader/libsl2.so`.
-This modloader has several call in points. It performs a topological sort of all depenents that need to be loaded and loads them in turn. `libs` are loaded very early, on `modloader_load`, while `early_mods` are also constructed at this time. `early_mods` have their `load` function called on them after `il2cpp_init`, which is hooked via [Flamingo](https://github.com/sc2ad/Flamingo) to allow us to perform loading at a sufficiently late time.
+This modloader has several call in points. It performs a topological sort of all depenents that need to be loaded and loads them in turn. `libs` are loaded very early, on `modloader_load`, while `early_mods` are also constructed at this time. `early_mods` have their `load` function called on them after `il2cpp_init`, which is hooked via [Flamingo](https://github.com/sc2ad/Flamingo) to allow us to perform loading at a sufficiently late time. early mods will also have a function named `late_load` called when mods are constructed, but more on that in the next paragraph.
 
-`mods` WILL be loaded on some unity initialization function, currently TBD.
+`mods` will be constructed when the libunity.so method `UnityPostLoadApplication` is called. This method is hooked with flamingo through an xref trace through JNI_Onload all the way to that method. After mods are opened and constructed, early mods get their late_load method called, after which mods will get their load and late_load methods called.
+
+Here is a table containing what gets opened and called when.
+ - `dlopen` means the .so file will be opened at that time.
+ - `setup` means the setup method which fills the mod info is called at that point.
+ - `load` means the load method is called at that point
+ - `late_load` means that that is when late_load is invoked.
+
+|                          | Lib      | Early Mod        | Mod                                    |
+|--------------------------|----------|------------------|----------------------------------------|
+| app start                | `dlopen` | `dlopen`, `setup`| -                                      |
+| il2cpp_init              | -        | `load`           | -                                      |
+| UnityPostLoadApplication | -        | `late_load`      | `dlopen`, `setup`, `load`, `late_load` |

--- a/include/capstone-utils.hpp
+++ b/include/capstone-utils.hpp
@@ -1,0 +1,303 @@
+#pragma once
+#include <array>
+#include <optional>
+#include <tuple>
+#include "capstone/shared/capstone/capstone.h"
+#include "capstone/shared/platform.h"
+#include "log.h"
+
+namespace cs {
+csh getHandle();
+
+uint32_t* readb(uint32_t const* addr);
+
+template <arm64_insn... args>
+constexpr bool insnMatch(cs_insn* insn) {
+  if constexpr (sizeof...(args) > 0) {
+    return (((insn->id == args) || ...));
+  }
+  return false;
+};
+
+struct AddrSearchPair {
+  AddrSearchPair(uint32_t const* addr_, uint32_t remSearchSize_) : addr(addr_), remSearchSize(remSearchSize_) {}
+  uint32_t const* addr;
+  uint64_t remSearchSize;
+};
+
+auto find_through_hooks(void const* hook, uint32_t initialSearchSize, auto&& func) {
+  return func(cs::AddrSearchPair(reinterpret_cast<uint32_t const*>(hook), initialSearchSize));
+}
+
+template <std::size_t sz, class F1, class F2>
+decltype(auto) findNth(std::array<AddrSearchPair, sz>& addrs, uint32_t nToRetOn, int retCount, F1&& match, F2&& skip) {
+  cs_insn* insn = cs_malloc(getHandle());
+  for (std::size_t searchIdx = 0; searchIdx < addrs.size(); searchIdx++) {
+    while (addrs[searchIdx].remSearchSize > 0) {
+      auto ptr = reinterpret_cast<uint64_t>(addrs[searchIdx].addr);
+      bool res = cs_disasm_iter(getHandle(), reinterpret_cast<uint8_t const**>(&addrs[searchIdx].addr),
+                                &addrs[searchIdx].remSearchSize, &ptr, insn);
+      LOG_DEBUG("{} diassemb: {} (rCount: {}, nToRetOn: {}, sz: {})", fmt::ptr((void*)ptr), insn->mnemonic, retCount,
+                nToRetOn, addrs[searchIdx].remSearchSize);
+      if (res) {
+        // Valid decode, so lets check to see if it is a match or we need to break.
+        if (insn->id == ARM64_INS_RET) {
+          if (retCount == 0) {
+            // Early termination!
+            cs_free(insn, 1);
+            LOG_WARN("Could not find: {} call at: {} within: {} rets! Found all of the rets first!", nToRetOn,
+                     fmt::ptr(addrs[searchIdx].addr), retCount);
+            return (decltype(match(insn)))std::nullopt;
+          }
+          retCount--;
+        } else {
+          auto testRes = match(insn);
+          if (testRes) {
+            if (nToRetOn == 1) {
+              cs_free(insn, 1);
+              return testRes;
+            } else {
+              nToRetOn--;
+            }
+          } else if (skip(insn)) {
+            if (nToRetOn == 1) {
+              std::string name(insn->mnemonic);
+              cs_free(insn, 1);
+              LOG_WARN(
+                  "Found: {} match, at: {} within: {} rets, but the result was a {}! Cannot compute destination "
+                  "address!",
+                  nToRetOn, fmt::ptr(addrs[searchIdx].addr), retCount, name);
+              return (decltype(match(insn)))std::nullopt;
+            } else {
+              nToRetOn--;
+            }
+          }
+        }
+        // Other instructions are ignored silently
+      } else {
+        // Invalid instructions are ignored silently.
+        // In order to skip these properly, we must increment our instructions, ptr, and size accordingly.
+        addrs[searchIdx].remSearchSize -= 4;
+        addrs[searchIdx].addr++;
+      }
+    }
+    // We didn't find it. Let's instead look at the next address/size pair for a match.
+    LOG_DEBUG("Could not find: {} call at: {} within: {} rets at idx: {}!", nToRetOn, fmt::ptr(addrs[searchIdx].addr),
+              retCount, searchIdx);
+  }
+  // If we run out of bytes to parse, we fail
+  cs_free(insn, 1);
+  return (decltype(match(insn)))std::nullopt;
+}
+
+template <uint32_t nToRetOn, int retCount = -1, size_t szBytes = 4096, class F1, class F2>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNth(uint32_t const* addr, F1&& match, F2&& skip) {
+  cs_insn* insn = cs_malloc(getHandle());
+  auto ptr = reinterpret_cast<uint64_t>(addr);
+  auto instructions = reinterpret_cast<uint8_t const*>(addr);
+
+  int rCount = retCount;
+  uint32_t nCalls = nToRetOn;
+  size_t sz = szBytes;
+  while (sz > 0) {
+    bool res = cs_disasm_iter(getHandle(), &instructions, &sz, &ptr, insn);
+    LOG_DEBUG("{} diassemb: {} (rCount: {}, nCalls: {}, sz: {})", fmt::ptr(ptr), insn->mnemonic, rCount, nCalls, sz);
+    if (res) {
+      // Valid decode, so lets check to see if it is a match or we need to break.
+      if (insn->id == ARM64_INS_RET) {
+        if (rCount == 0) {
+          // Early termination!
+          cs_free(insn, 1);
+          LOG_WARN("Could not find: {} call at: {} within: {} rets! Found all of the rets first!", nToRetOn,
+                   fmt::ptr(ptr), retCount);
+          return (decltype(match(insn)))std::nullopt;
+        }
+        rCount--;
+      } else {
+        auto testRes = match(insn);
+        if (testRes) {
+          if (nCalls == 1) {
+            cs_free(insn, 1);
+            return testRes;
+          } else {
+            nCalls--;
+          }
+        } else if (skip(insn)) {
+          if (nCalls == 1) {
+            std::string name(insn->mnemonic);
+            cs_free(insn, 1);
+            LOG_WARN(
+                "Found: {} match, at: {} within: {} rets, but the result was a {}! Cannot compute destination address!",
+                nToRetOn, fmt::ptr(ptr), retCount, name);
+            return (decltype(match(insn)))std::nullopt;
+          } else {
+            nCalls--;
+          }
+        }
+      }
+      // Other instructions are ignored silently
+    } else {
+      // Invalid instructions are ignored silently.
+      // In order to skip these properly, we must increment our instructions, ptr, and size accordingly.
+      sz -= 4;
+      ptr += 4;
+      instructions += 4;
+    }
+  }
+  // If we run out of bytes to parse, we fail
+  cs_free(insn, 1);
+  LOG_WARN("Could not find: {} call at: {} within: {} rets, within size: {}!", nToRetOn, fmt::ptr(addr), retCount,
+           szBytes);
+  return (decltype(match(insn)))std::nullopt;
+}
+
+template <uint32_t nToRetOn, auto match, auto skip, int retCount = -1, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNth(uint32_t const* addr) {
+  cs_insn* insn = cs_malloc(getHandle());
+  auto ptr = reinterpret_cast<uint64_t>(addr);
+  auto instructions = reinterpret_cast<uint8_t const*>(addr);
+
+  int rCount = retCount;
+  uint32_t nCalls = nToRetOn;
+  size_t sz = szBytes;
+  while (sz > 0) {
+    bool res = cs_disasm_iter(getHandle(), &instructions, &sz, &ptr, insn);
+    LOG_DEBUG("{} diassemb: {} (rCount: {}, nCalls: {}, sz: {})", fmt::ptr((void*)ptr), insn->mnemonic, rCount, nCalls,
+              sz);
+    if (res) {
+      // Valid decode, so lets check to see if it is a match or we need to break.
+      if (insn->id == ARM64_INS_RET) {
+        if (rCount == 0) {
+          // Early termination!
+          cs_free(insn, 1);
+          LOG_WARN("Could not find: {} call at: {} within: {} rets! Found all of the rets first!", nToRetOn,
+                   fmt::ptr((void*)ptr), retCount);
+          return (decltype(match(insn)))std::nullopt;
+        }
+        rCount--;
+      } else {
+        auto testRes = match(insn);
+        if (testRes) {
+          if (nCalls == 1) {
+            cs_free(insn, 1);
+            return testRes;
+          } else {
+            nCalls--;
+          }
+        } else if (skip(insn)) {
+          if (nCalls == 1) {
+            std::string name(insn->mnemonic);
+            cs_free(insn, 1);
+            LOG_WARN(
+                "Found: {} match, at: {} within: {} rets, but the result was a {}! Cannot compute destination address!",
+                nToRetOn, fmt::ptr((void*)ptr), retCount, name);
+            return (decltype(match(insn)))std::nullopt;
+          } else {
+            nCalls--;
+          }
+        }
+      }
+      // Other instructions are ignored silently
+    } else {
+      // Invalid instructions are ignored silently.
+      // In order to skip these properly, we must increment our instructions, ptr, and size accordingly.
+      LOG_WARN("FAILED PARSE: {} diassemb: 0x{:x}", fmt::ptr((void*)ptr), *(uint32_t*)ptr);
+      sz -= 4;
+      ptr += 4;
+      instructions += 4;
+    }
+  }
+  // If we run out of bytes to parse, we fail
+  cs_free(insn, 1);
+  return (decltype(match(insn)))std::nullopt;
+}
+
+std::optional<uint32_t*> blConv(cs_insn* insn);
+
+template <uint32_t nToRetOn, bool includeR = false, int retCount = -1, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNthBl(uint32_t const* addr) {
+  return find_through_hooks(addr, szBytes, [](auto... pairs) {
+    std::array addrs{ pairs... };
+    if constexpr (includeR) {
+      return findNth(addrs, nToRetOn, retCount, &blConv, &insnMatch<ARM64_INS_BLR>);
+    } else {
+      return findNth(addrs, nToRetOn, retCount, &blConv, &insnMatch<>);
+    }
+  });
+}
+
+std::optional<uint32_t*> bConv(cs_insn* insn);
+
+template <uint32_t nToRetOn, bool includeR = false, int retCount = -1, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNthB(uint32_t const* addr) {
+  return find_through_hooks(addr, szBytes, [](auto... pairs) {
+    std::array addrs{ pairs... };
+    if constexpr (includeR) {
+      return findNth(addrs, nToRetOn, retCount, &bConv, &insnMatch<ARM64_INS_BR>);
+    } else {
+      return findNth(addrs, nToRetOn, retCount, &bConv, &insnMatch<>);
+    }
+  });
+}
+
+std::optional<std::tuple<uint32_t*, arm64_reg, uint32_t*>> pcRelConv(cs_insn* insn);
+
+template <uint32_t nToRetOn, int retCount = -1, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNthPcRel(uint32_t const* addr) {
+  return find_through_hooks(addr, szBytes, [](auto... pairs) {
+    std::array addrs{ pairs... };
+    return findNth(addrs, nToRetOn, retCount, &pcRelConv, &insnMatch<>);
+  });
+}
+
+std::optional<std::tuple<uint32_t*, arm64_reg, int64_t>> regMatchConv(cs_insn* match, arm64_reg toMatch);
+
+template <uint32_t nToRetOn, int retCount = -1, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && (szBytes % 4) == 0))
+auto findNthReg(uint32_t const* addr, arm64_reg reg) {
+  auto lmd = [reg](cs_insn* in) -> std::optional<std::tuple<uint32_t*, arm64_reg, int64_t>> {
+    return regMatchConv(in, reg);
+  };
+  return find_through_hooks(addr, szBytes, [lmd = std::move(lmd)](auto... pairs) {
+    std::array addrs{ pairs... };
+    return findNth(addrs, nToRetOn, retCount, lmd, &insnMatch<>);
+  });
+}
+
+template <uint32_t nToRetOn, uint32_t nImmOff, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && nImmOff >= 1 && (szBytes % 4) == 0))
+std::optional<std::tuple<uint32_t*, arm64_reg, uint32_t*>> getpcaddr(uint32_t const* addr) {
+  auto pcrel = findNthPcRel<nToRetOn, -1, szBytes>(addr);
+  // SAFE_ABORT_MSG("Could not find: %u pcrel at: %p within: %i rets, within size: %zu!", nToRetOn, addr, -1, szBytes);
+  if (!pcrel) return std::nullopt;
+  // addr is in first slot of tuple, reg in second, dst imm in third
+  // TODO: decrease size correctly
+  auto reginst = findNthReg<nImmOff, -1, szBytes>(std::get<0>(*pcrel), std::get<1>(*pcrel));
+  // SAFE_ABORT_MSG("Could not find: %u reg with reg: %u at: %p within: %i rets, within size: %zu!", nImmOff,
+  // std::get<1>(*pcrel), std::get<0>(*pcrel), -1, szBytes);
+  if (!reginst) return std::nullopt;
+  return std::make_tuple(
+      std::get<0>(*reginst), std::get<1>(*reginst),
+      reinterpret_cast<uint32_t*>(reinterpret_cast<uint64_t>(std::get<2>(*pcrel)) + std::get<2>(*reginst)));
+}
+
+template <uint32_t nToRetOn, uint32_t nImmOff, int match, size_t szBytes = 4096>
+  requires((nToRetOn >= 1 && nImmOff >= 1 && (szBytes % 4) == 0))
+std::optional<uint32_t*> evalswitch(uint32_t const* addr) {
+  // Get matching adr/adrp + offset on register
+  auto res = getpcaddr<nToRetOn, nImmOff, szBytes>(addr);
+  // SAFE_ABORT_MSG("Could not find: %u pcrel at: %p within: %i rets, within size: %zu!", nToRetOn, addr, -1, szBytes);
+  if (!res) return std::nullopt;
+  // Convert destination to the switch table address
+  auto switchTable = reinterpret_cast<int32_t*>(std::get<2>(*res));
+  // Index into switch table, which holds int32s, offset from start of switch table
+  auto val = switchTable[match - 1];
+  // Add offset to switch table and convert back to pointer type
+  return reinterpret_cast<uint32_t*>(reinterpret_cast<uint64_t>(switchTable) + val);
+}
+}  // namespace cs

--- a/include/internal-loader.hpp
+++ b/include/internal-loader.hpp
@@ -34,9 +34,12 @@ std::vector<SharedObject> listAllObjectsInPhase(std::filesystem::path const& dep
 /// @param filesDir The destination to copy the libraries to in order to ensure correct permissions.
 void open_libs(std::filesystem::path const& filesDir) noexcept;
 
+/// @brief Opens the early mods from the @ref loadPhaseMap and places them in the filesDir provided.
+/// @param filesDir The destination to copy the early mods to in order to ensure correct permissions.
 void open_early_mods(std::filesystem::path const& filesDir) noexcept;
 
-void load_mods() noexcept;
+/// @brief Calls load on early mods
+void load_early_mods() noexcept;
 
 void close_all() noexcept;
 

--- a/include/internal-loader.hpp
+++ b/include/internal-loader.hpp
@@ -45,7 +45,7 @@ void open_mods(std::filesystem::path const& filesDir) noexcept;
 /// @brief Calls load on early mods
 void load_early_mods() noexcept;
 
-/// @brief Calls late_load on early mods, load and late_load
+/// @brief Calls late_load on mods and early mods
 void load_mods() noexcept;
 
 void close_all() noexcept;

--- a/include/internal-loader.hpp
+++ b/include/internal-loader.hpp
@@ -38,8 +38,15 @@ void open_libs(std::filesystem::path const& filesDir) noexcept;
 /// @param filesDir The destination to copy the early mods to in order to ensure correct permissions.
 void open_early_mods(std::filesystem::path const& filesDir) noexcept;
 
+/// @brief Opens the mods from the @ref loadPhaseMap and places them in the filesDir provided.
+/// @param filesDir The destination to copy the mods to in order to ensure correct permissions.
+void open_mods(std::filesystem::path const& filesDir) noexcept;
+
 /// @brief Calls load on early mods
 void load_early_mods() noexcept;
+
+/// @brief Calls late_load on early mods, load and late_load
+void load_mods() noexcept;
 
 void close_all() noexcept;
 

--- a/shared/loader.hpp
+++ b/shared/loader.hpp
@@ -183,7 +183,8 @@ struct LoadedMod {
   LoadedMod& operator=(LoadedMod const&) = delete;
 
   LoadedMod(ModInfo modInfo, SharedObject object, LoadPhase phase, std::optional<SetupFunc> setupFn,
-            std::optional<LoadFunc> loadFn, std::optional<LateLoadFunc> late_loadFn, std::optional<UnloadFunc> unloadFn, void* handle)
+            std::optional<LoadFunc> loadFn, std::optional<LateLoadFunc> late_loadFn, std::optional<UnloadFunc> unloadFn,
+            void* handle)
       : modInfo(std::move(modInfo)),
         object(std::move(object)),
         phase(phase),

--- a/shared/loader.hpp
+++ b/shared/loader.hpp
@@ -222,7 +222,7 @@ struct LoadedMod {
   }
 
   /// @brief Calls the late_load function on the mod
-  /// @return true if thje call exists and was called, false otherwise
+  /// @return true if the call exists and was called, false otherwise
   inline bool late_load() noexcept {
     if (late_loadFn) {
       (*late_loadFn)();

--- a/src/capstone-utils.cpp
+++ b/src/capstone-utils.cpp
@@ -1,0 +1,101 @@
+#include "capstone-utils.hpp"
+#include <android/log.h>
+
+csh handle;
+bool valid = false;
+
+#ifndef VERSION
+#define VERSION "0.0.0"
+#endif
+
+#ifndef ID
+#define ID "scotland2"
+#endif
+
+namespace cs {
+void __attribute__((constructor)) init_capstone() {
+  cs_err e1 = cs_open(CS_ARCH_ARM64, CS_MODE_ARM, &handle);
+  cs_option(handle, CS_OPT_DETAIL, 1);
+  if (e1) {
+    LOG_ERROR("Capstone initialization failed! {}", static_cast<int>(e1));
+  }
+  LOG_INFO("Capstone initialized!");
+  valid = true;
+}
+
+csh getHandle() {
+  return handle;
+}
+
+#define RET_0_UNLESS(v) \
+  if (!(v)) return 0;
+
+uint32_t* readb(uint32_t const* addr) {
+  cs_insn* insns;
+  // Read from addr, 1 instruction, with pc at addr, into insns.
+  // TODO: consider using cs_disasm_iter
+  auto count = cs_disasm(handle, reinterpret_cast<uint8_t const*>(addr), sizeof(uint32_t),
+                         reinterpret_cast<uint64_t>(addr), 1, &insns);
+
+  RET_0_UNLESS(count == 1);
+  auto inst = insns[0];
+  // Thunks have a single b
+  RET_0_UNLESS(inst.id == ARM64_INS_B);
+  auto platinsn = inst.detail->arm64;
+  RET_0_UNLESS(platinsn.op_count == 1);
+  auto op = platinsn.operands[0];
+  RET_0_UNLESS(op.type == ARM64_OP_IMM);
+  // Our b dest is addr + (imm << 2), except capstone does this for us.
+  auto dst = reinterpret_cast<uint32_t*>(op.imm);
+  cs_free(insns, 1);
+  return dst;
+}
+
+std::optional<uint32_t*> blConv(cs_insn* insn) {
+  if (insn->id == ARM64_INS_BL) {
+    // BL is pc + (imm << 2), capstone handles this
+    return reinterpret_cast<uint32_t*>(insn->detail->arm64.operands[0].imm);
+  }
+  return std::nullopt;
+}
+
+std::optional<uint32_t*> bConv(cs_insn* insn) {
+  if (insn->id == ARM64_INS_B) {
+    // B is pc + (imm << 2), capstone handles this
+    return reinterpret_cast<uint32_t*>(insn->detail->arm64.operands[0].imm);
+  }
+  return std::nullopt;
+}
+
+std::optional<std::tuple<uint32_t*, arm64_reg, uint32_t*>> pcRelConv(cs_insn* insn) {
+  using tup = std::tuple<uint32_t*, arm64_reg, uint32_t*>;
+  switch (insn->id) {
+    case ARM64_INS_ADR:
+    // ADR is just pc + imm, capstone handles this
+    case ARM64_INS_ADRP:
+      // ADRP is (pc & 1:12(0)) + (imm << 12), capstone handles this
+      return tup{ reinterpret_cast<uint32_t*>(insn->address), insn->detail->arm64.operands[0].reg,
+                  reinterpret_cast<uint32_t*>(insn->detail->arm64.operands[1].imm) };
+    default:
+      return std::nullopt;
+  }
+}
+
+std::optional<std::tuple<uint32_t*, arm64_reg, int64_t>> regMatchConv(cs_insn* match, arm64_reg toMatch) {
+  // We need 1 to 2 operands, match 1 to 2 to register, determine dst reg from incoming instruction
+  // For now, it's pretty common for add immediates, which have dst as first op, src 2nd, imm third
+  auto& arm = match->detail->arm64;
+  using tup = std::tuple<uint32_t*, arm64_reg, int64_t>;
+  switch (match->id) {
+    case ARM64_INS_ADD:
+      if (arm.operands[1].reg != toMatch) return std::nullopt;
+      return tup{ reinterpret_cast<uint32_t*>(match->address), arm.operands[0].reg, arm.operands[2].imm };
+    case ARM64_INS_LDR:
+      if (arm.operands[1].mem.base != toMatch) return std::nullopt;
+      return tup{ reinterpret_cast<uint32_t*>(match->address), arm.operands[0].reg, arm.operands[1].mem.disp };
+    // TODO: Add more conversions for instructions!
+    default:
+      return std::nullopt;
+  }
+}
+}  // namespace cs

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -386,9 +386,10 @@ std::vector<LoadResult> loadMod(SharedObject&& mod, std::filesystem::path const&
 
     auto setupFn = getFunction<SetupFunc>(handle, "setup");
     auto loadFn = getFunction<LoadFunc>(handle, "load");
+    auto late_loadFn = getFunction<LateLoadFunc>(handle, "late_load");
     auto unloadFn = getFunction<UnloadFunc>(handle, "unload");
 
-    return LoadedMod(modInfo, std::move(obj), phase, setupFn, loadFn, unloadFn, handle);
+    return LoadedMod(modInfo, std::move(obj), phase, setupFn, loadFn, late_loadFn, unloadFn, handle);
   };
 
   auto deps = mod.getToLoad(dependencyDir, phase);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,7 @@ uint32_t* find_unity_hook_loc([[maybe_unused]] JNIEnv* env, [[maybe_unused]] voi
   // this is not guaranteed to be the size across every libunty ever,
   // therefore it not matching is not cause for erroring out of the xref trace
   if (methsz != 0x19) {
-    LOG_ERROR("Method size found was {} (0x{:x}), while 25 (0x19) was expected", methsz, methsz);
+    LOG_WARN("Method size found was {} (0x{:x}), while 25 (0x19) was expected", methsz, methsz);
     LOG_DEBUG("Despite wrong method size, lookup will still be attempted, this could crash!");
   } else {
     LOG_DEBUG("Found native method array size {} (0x{:x})", methsz, methsz);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -258,6 +258,7 @@ void install_unity_hook(uint32_t* target) {
   // if we did anything with gameobjects before this, it would clear them here, so we load our late mods *after*
   // that way, mods can create GameObjects and other unity objects at dlopen time if they want to.
   auto unity_hook = [](void* param_1) noexcept {
+    // TODO: uninstall hook after first call
     // First param is assumed to be a linked list, stored on the SceneManager.
     // this linked list is iterated over by ClearRoots and all unity objects are destroyed.
     LOG_DEBUG("ClearRoots called with param {}", fmt::ptr(param_1));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,6 +66,8 @@ void install_load_hook(uint32_t* target) {
   // TODO: mprotect memory again after we are done writing
   target_hook.WriteCallback(reinterpret_cast<uint32_t*>(+init_hook));
   target_hook.Finish();
+  __flush_cache(target, sizeof(uint32_t) * 4);
+
   FLAMINGO_DEBUG("Hook installed! Target: {} (il2cpp_init) now will call: {} (hook), with trampoline: {}",
                  fmt::ptr(target), fmt::ptr(+init_hook), fmt::ptr(trampoline.address.data()));
 }
@@ -274,6 +276,8 @@ void install_unity_hook(uint32_t* target) {
   };
   target_hook.WriteCallback(reinterpret_cast<uint32_t*>(+unity_hook));
   target_hook.Finish();
+  __flush_cache(target, sizeof(uint32_t) * 4);
+
   // TODO: mprotect memory again after we are done writing
   FLAMINGO_DEBUG("Hook installed! Target: {} (ClearRoots) now will call: {} (hook), with trampoline: {}",
                  fmt::ptr(target), fmt::ptr(+unity_hook), fmt::ptr(trampoline.address.data()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,6 @@ void install_load_hook(uint32_t* target) {
   }
   static flamingo::Trampoline target_hook(target, hookSize, trampoline_size);
   auto init_hook = [](char const* domain_name) noexcept {
-    // TODO: uninstall hook after first call
     // Call orig first
     LOG_DEBUG("il2cpp_init called with: {}", domain_name);
     reinterpret_cast<void (*)(char const*)>(trampoline.address.data())(domain_name);
@@ -294,7 +293,6 @@ void install_unity_hook(uint32_t* target) {
   // if we did anything with gameobjects before this, it would clear them here, so we load our late mods *after*
   // that way, mods can create GameObjects and other unity objects at dlopen time if they want to.
   auto unity_hook = [](void* param_1) noexcept {
-    // TODO: uninstall hook after first call
     // First param is assumed to be a linked list, stored on the SceneManager.
     // this linked list is iterated over by ClearRoots and all unity objects are destroyed.
     LOG_DEBUG("ClearRoots called with param {}", fmt::ptr(param_1));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ void install_load_hook(uint32_t* target) {
     // Call orig first
     LOG_DEBUG("il2cpp_init called with: {}", domain_name);
     reinterpret_cast<void (*)(char const*)>(trampoline.address.data())(domain_name);
-    modloader::load_mods();
+    modloader::load_early_mods();
   };
   target_hook.WriteCallback(reinterpret_cast<uint32_t*>(+init_hook));
   target_hook.Finish();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,9 +113,55 @@ uintptr_t baseAddr(char const* soname, void* imagehandle) {
   return (uintptr_t)NULL;
 }
 
-static std::optional<uint32_t*> movzFind(cs_insn* insn) {
-  return (insn->id == ARM64_INS_MOVZ) ? std::optional<uint32_t*>(reinterpret_cast<uint32_t*>(insn->address))
-                                      : std::nullopt;
+template <auto ins>
+static std::optional<uint32_t*> findIns(cs_insn* insn) {
+  return (insn->id == ins) ? std::optional<uint32_t*>(reinterpret_cast<uint32_t*>(insn->address)) : std::nullopt;
+}
+
+/// @return optional tuple containing found tbz ins, offset it requests off of itself, and the offset it points to, or
+/// nullopt if not found
+template <auto ret_on>
+static std::optional<std::tuple<uint32_t*, uint32_t, uint32_t*>> getTbzAddr(uint32_t* address) {
+  // the label to jump to for tbz is 14 bits wide
+  auto tbz = cs::findNth<ret_on, &findIns<ARM64_INS_TBZ>, cs::insnMatch<>, 1>(address);
+  if (!tbz) return std::nullopt;
+
+  static constexpr auto mask = 0x3fff;
+  static constexpr auto pos = 5;
+  auto offset = (**tbz >> pos) & mask;
+  return { { *tbz, offset, *tbz + offset } };
+}
+
+struct BCond {
+  uint32_t cond : 4;        // arm64 conditional
+  const uint32_t zero : 1;  // always 0
+  uint32_t offset : 19;     // offset off of this instruction
+  uint32_t ins : 8;         // instruction bits
+};
+static_assert(sizeof(BCond) == sizeof(uint32_t));
+
+/// @brief matches a b.cond where cond is an arm64_cc conditional
+template <arm64_cc condition>
+static std::optional<uint32_t*> matchBCond(cs_insn* insn) {
+  static constexpr auto b_cond_ins = 0x54;
+  // the arm64_cc enum is consistently the actual conditionals + 1
+  static constexpr auto actual_condition = (condition - 1);
+  auto const bcond = reinterpret_cast<BCond*>(insn->address);
+  // if we are not a b conditional
+  if (bcond->ins != b_cond_ins) return std::nullopt;
+  if (bcond->cond != actual_condition) return std::nullopt;
+  return reinterpret_cast<uint32_t*>(insn->address);
+}
+
+/// @brief gets the nth bCondAddr, and returns a tuple containing the address of the found b.cond, the offset it will
+/// jump and the target address. returns nullopt if not found
+template <size_t ret_on, arm64_cc condition>
+static std::optional<std::tuple<uint32_t*, uint32_t, uint32_t*>> getBCondAddr(uint32_t* address) {
+  auto bcond = cs::findNth<ret_on, &matchBCond<condition>, &cs::insnMatch<>, 1>(address);
+  if (!bcond) return std::nullopt;
+
+  auto bc = reinterpret_cast<BCond*>(*bcond);
+  return { { *bcond, (uint32_t)bc->offset, *bcond + bc->offset } };
 }
 
 #define RET_NULL_LOG_UNLESS(v)       \
@@ -157,7 +203,7 @@ uint32_t* find_unity_hook_loc([[maybe_unused]] JNIEnv* env, [[maybe_unused]] voi
   JNINativeMethod* meths = reinterpret_cast<JNINativeMethod*>(std::get<2>(*s_UnityPlayerMethods));
 
   // get the size of the method array
-  auto movSz = cs::findNth<1, &movzFind, &cs::insnMatch<>, 1>(*registerNatives);
+  auto movSz = cs::findNth<1, &findIns<ARM64_INS_MOVZ>, &cs::insnMatch<>, 1>(*registerNatives);
   RET_NULL_LOG_UNLESS(movSz);
   auto ins = **movSz;
   auto methsz = (ins >> 5) & 0xffff;
@@ -192,8 +238,27 @@ uint32_t* find_unity_hook_loc([[maybe_unused]] JNIEnv* env, [[maybe_unused]] voi
   RET_NULL_LOG_UNLESS(unityplayerloop);
   LOG_OFFSET("UnityPlayerLoop", *unityplayerloop);
 
-  // this gets called after the first scene has loaded and unity has initialized
-  auto unitypostloadapplication = cs::findNthBl<20>(*unityplayerloop);
+  // we want to find UnityPostLoadApplication, we can do this either by finding the 20th or so bl, but this breaks
+  // across different unity versions. A different strategy is to follow a few jumps across labels, and end up at the
+  // right label instead to get the second bl there.
+
+  auto pendingWindow = getTbzAddr<2>(*unityplayerloop);
+  RET_NULL_LOG_UNLESS(pendingWindow);
+  LOG_OFFSET("pendingWindow check", std::get<2>(*pendingWindow));
+
+  auto levelLoaded = getTbzAddr<1>(std::get<2>(*pendingWindow));
+  RET_NULL_LOG_UNLESS(levelLoaded);
+  LOG_OFFSET("levelLoaded check", std::get<2>(*levelLoaded));
+
+  auto initialized = getBCondAddr<1, ARM64_CC_NE>(std::get<2>(*levelLoaded));
+  RET_NULL_LOG_UNLESS(initialized);
+  LOG_OFFSET("initialized check", std::get<2>(*initialized));
+
+  auto splashScreen = getTbzAddr<1>(std::get<2>(*initialized));
+  RET_NULL_LOG_UNLESS(splashScreen);
+  LOG_OFFSET("splashScreen check", std::get<2>(*splashScreen));
+
+  auto unitypostloadapplication = cs::findNthBl<2>(std::get<2>(*splashScreen));
   RET_NULL_LOG_UNLESS(unitypostloadapplication);
   LOG_OFFSET("UnityPostLoadApplication", *unitypostloadapplication);
 

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -209,7 +209,7 @@ void load_early_mods() noexcept {
   }
 }
 
-// calls load on mods, late_load on early mods
+// calls late_load on mods and early mods
 void load_mods() noexcept {
   // call late_load on all early mods
   for (auto& m : loaded_early_mods) {
@@ -224,20 +224,15 @@ void load_mods() noexcept {
     }
   }
 
-  // call load and late_load on all mods
+  // call late_load on all mods
   for (auto& m : loaded_mods) {
     if (auto* loaded_mod = std::get_if<LoadedMod>(&m)) {
-      if (!loaded_mod->load()) {
-        // Load call does not exist, but the mod was still loaded
-        LOG_INFO("No load function on mod: {}", loaded_mod->object.path.c_str());
-      }
-      // next we call late load on the mod
       if (!loaded_mod->late_load()) {
         // Load call does not exist, but the mod was still loaded
-        LOG_INFO("No load function on mod: {}", loaded_mod->object.path.c_str());
+        LOG_INFO("No late_load function on mod: {}", loaded_mod->object.path.c_str());
       }
     } else if (auto* fail = std::get_if<FailedMod>(&m)) {
-      LOG_WARN("Skipping load call on: {} because it failed to be constructed: {}", fail->object.path.c_str(),
+      LOG_WARN("Skipping late_load call on: {} because it failed to be constructed: {}", fail->object.path.c_str(),
                fail->failure.c_str());
     }
   }

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -81,8 +81,13 @@ void statdump([[maybe_unused]] fs::path const& path) {}
 void ensure_dir_exists(std::filesystem::path const& dir) {
   // First, statdump the dir
   statdump(dir);
-  // Next, attempt to create the directory
   std::error_code err{};
+  // Then check whether it exists
+  if (std::filesystem::exists(dir, err)) {
+    LOG_WARN("Directory {} already existed", dir.c_str());
+    return;
+  }
+  // Next, attempt to create the directory
   if (!std::filesystem::create_directories(dir, err)) {
     LOG_WARN("Failed to make directory: {}, err: {}", dir.c_str(), err.message());
     return;

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -176,7 +176,7 @@ void open_early_mods(std::filesystem::path const& filesDir) noexcept {
   }
 }
 
-void load_mods() noexcept {
+void load_early_mods() noexcept {
   // Call load on all early mods
   for (auto& m : loaded_early_mods) {
     if (auto* loaded_mod = std::get_if<LoadedMod>(&m)) {


### PR DESCRIPTION
 - Rename `load_mods` to `load_early_mods` to better reflect what it does
 - Add opening of mods (aka late mods) after the unity method call of `UnityPostLoadApplication`
 - Add load call of those mods right after dlopening them
 - Add `late_load` entry point for early mods and mods, called after mods are dlopened. For mods there is basically no difference between `load` and `late_load`, since they are executed directly after one another. mods just get `late_load` called in order to reduce friction for mod developers