### PR TITLE
Add shims folder

### DIFF
--- a/.github/workflows/build-ndk.yml
+++ b/.github/workflows/build-ndk.yml
@@ -56,14 +56,14 @@ jobs:
           echo ::set-output name=NAME::"${files[0]}"
 
       - name: Upload non-debug artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.libname.outputs.NAME }}
           path: ./build/${{ steps.libname.outputs.NAME }}
           if-no-files-found: error
 
       - name: Upload debug artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: debug_${{ steps.libname.outputs.NAME }}
           path: ./build/debug_${{ steps.libname.outputs.NAME }}

--- a/build.ps1
+++ b/build.ps1
@@ -1,18 +1,16 @@
+Param(
+    [Parameter(Mandatory = $false)]
+    [Switch] $clean
+)
 
-function Clean-Build-Folder {
+if ($clean.IsPresent) {
     if (Test-Path -Path "build") {
-        remove-item build -R
-        new-item -Path build -ItemType Directory
-    }
-    else {
-        new-item -Path build -ItemType Directory
+        Remove-Item build -R
     }
 }
-
-$NDKPath = Get-Content $PSScriptRoot/ndkpath.txt
-
-# Clean-Build-Folder
-# build tests
+if (-not (Test-Path -Path "build")) {
+    New-Item -Path build -ItemType Directory
+}
 
 & cmake -G "Ninja" -DCMAKE_BUILD_TYPE="RelWithDebInfo" -B build
 & cmake --build ./build
@@ -22,6 +20,5 @@ $ExitCode = $LastExitCode
 # Post build, we actually want to transform the compile_commands.json file such that it has no \\ characters and ONLY has / characters
 (Get-Content -Path build/compile_commands.json) |
 ForEach-Object { $_ -Replace '\\\\', '/' } | ForEach-Object { $_ -Replace '/\\"', '\\\"' } | Set-Content -Path build/compile_commands.json
-
 
 exit $ExitCode

--- a/copy.ps1
+++ b/copy.ps1
@@ -1,5 +1,9 @@
-& cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Debug" -DTEST_BUILD=1 -B build
-& cmake --build ./build
+Param(
+    [Parameter(Mandatory = $false)]
+    [Switch] $clean
+)
+
+& $PSScriptRoot/build.ps1 -clean:$clean
 
 & adb push ./build/libsl2.so /sdcard/ModData/com.beatgames.beatsaber/Modloader
 

--- a/qpm.json
+++ b/qpm.json
@@ -40,6 +40,9 @@
     "scripts": {
       "build": [
         "pwsh ./build.ps1"
+      ],
+      "copy": [
+        "pwsh ./copy.ps1"
       ]
     }
   }

--- a/qpm.json
+++ b/qpm.json
@@ -4,7 +4,7 @@
   "info": {
     "name": "scotland2",
     "id": "scotland2",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "url": "https://github.com/sc2ad/scotland2",
     "additionalData": {
       "overrideSoName": "libsl2.so"

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -6,7 +6,7 @@
     "info": {
       "name": "scotland2",
       "id": "scotland2",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "url": "https://github.com/sc2ad/scotland2",
       "additionalData": {
         "overrideSoName": "libsl2.so"

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,5 +1,6 @@
 {
   "config": {
+    "version": "0.1.0",
     "sharedDir": "shared",
     "dependenciesDir": "extern",
     "info": {
@@ -15,8 +16,14 @@
       "scripts": {
         "build": [
           "pwsh ./build.ps1"
+        ],
+        "copy": [
+          "pwsh ./copy.ps1"
         ]
-      }
+      },
+      "qmodIncludeDirs": [],
+      "qmodIncludeFiles": [],
+      "qmodOutput": null
     },
     "dependencies": [
       {

--- a/shared/loader.hpp
+++ b/shared/loader.hpp
@@ -36,6 +36,7 @@ enum struct LoadPhase {
   Libs,
   EarlyMods,
   Mods,
+  Shim,
 };
 
 #ifdef MODLOADER_USE_FMT
@@ -45,8 +46,11 @@ inline auto format_as(LoadPhase p) {
 #endif
 
 using namespace std::literals::string_view_literals;
-constexpr static ConstexprMap loadPhaseMap(std::array<std::pair<LoadPhase, std::string_view>, 3>{
-    { { LoadPhase::Libs, "libs"sv }, { LoadPhase::EarlyMods, "early_mods"sv }, { LoadPhase::Mods, "mods"sv } } });
+constexpr static ConstexprMap loadPhaseMap(std::array<std::pair<LoadPhase, std::string_view>, 4>{
+    { { LoadPhase::Libs, "libs"sv },
+      { LoadPhase::EarlyMods, "early_mods"sv },
+      { LoadPhase::Mods, "mods"sv },
+      { LoadPhase::Shim, "shims"sv } } });
 
 using MissingDependency = SharedObject;
 using DependencyResult = std::variant<MissingDependency, Dependency>;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -38,7 +38,7 @@ std::optional<std::pair<SharedObject, LoadPhase>> findSharedObject(std::filesyst
   // Search in reverse load order, starting at phase
   std::error_code error_code;
   for (auto const& it : loadPhaseMap.arr) {
-    if (it.first != phase) {
+    if (static_cast<int>(it.first) > static_cast<int>(phase) && it.first != LoadPhase::Shim) {
       continue;
     }
     auto path_to_check = dependencyDir / it.second / name;

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -563,6 +563,7 @@ MODLOADER_FUNC CLoadResultEnum modloader_require_mod(CModInfo* info, CMatchType 
   switch (loadedMod.phase) {
     case modloader::LoadPhase::None:
     case modloader::LoadPhase::Libs:
+    case modloader::LoadPhase::Shim:
       break;
     case modloader::LoadPhase::EarlyMods:
       if (!loadedMod.init()) {


### PR DESCRIPTION
Adds folder named `shims` next to `libs`, `mods`, etc for libraries to provide shim symbols, allowing for more advanced optional dependencies.
Objects in this folder will only be loaded if there is a direct dependency on them and no object is found with the same name in any of the other folders.