### PR TITLE
Stub JNI types

### DIFF
--- a/shared/modloader.h
+++ b/shared/modloader.h
@@ -90,9 +90,6 @@ typedef struct {
   size_t size;
 } CLoadResults;
 
-#ifdef __cplusplus
-}
-#endif
 /// @brief Returns true if the modloader failed to copy over the libs/mods to load, false otherwise
 MODLOADER_FUNC bool modloader_get_failed();
 /// @brief The captured pointer to the JavaVM
@@ -158,3 +155,7 @@ MODLOADER_FUNC bool modloader_add_ld_library_path(char const* path);
 // TODO: Add void** param to setup call, store as userdata in a given mod structure
 
 /*NOLINTEND(modernize-use-using)*/
+
+#ifdef __cplusplus
+}
+#endif

--- a/shared/modloader.h
+++ b/shared/modloader.h
@@ -2,7 +2,15 @@
 #pragma once
 
 // Exposed API functions
+#if __has_include(<jni.h>) || ANDROID
+#define MODLOADER_JNI
 #include <jni.h>
+typedef JavaVM* modloader_jvm_type;
+#else
+typedef void* modloader_jvm_type;
+#endif
+
+#include <stdbool.h>
 #include <stdint.h>
 #include "_config.h"
 
@@ -88,7 +96,7 @@ typedef struct {
 /// @brief Returns true if the modloader failed to copy over the libs/mods to load, false otherwise
 MODLOADER_FUNC bool modloader_get_failed();
 /// @brief The captured pointer to the JavaVM
-MODLOADER_EXPORT extern JavaVM* modloader_jvm;
+MODLOADER_EXPORT extern modloader_jvm_type modloader_jvm;
 /// @brief The captured dlopen-d libil2cpp.so handle
 MODLOADER_EXPORT extern void* modloader_libil2cpp_handle;
 /// @brief The captured dlopen-d libunity.so handle

--- a/src/modloader.cpp
+++ b/src/modloader.cpp
@@ -15,6 +15,8 @@
 #include "log.h"
 #include "modloader.h"
 
+extern "C" {
+
 MODLOADER_EXPORT JavaVM* modloader_jvm;
 MODLOADER_EXPORT void* modloader_libil2cpp_handle;
 MODLOADER_EXPORT void* modloader_unity_handle;
@@ -24,6 +26,7 @@ MODLOADER_EXPORT bool libs_opened;
 MODLOADER_EXPORT bool early_mods_opened;
 MODLOADER_EXPORT bool late_mods_opened;
 MODLOADER_EXPORT CLoadPhase current_load_phase = CLoadPhase::LoadPhase_None;
+}
 
 namespace {
 
@@ -207,7 +210,7 @@ void open_mods(std::filesystem::path const& filesDir) noexcept {
       LOG_INFO("{}", loaded_mod->object.path.c_str());
     }
   }
-  
+
   // Call initialize and report errors
   for (auto& m : loaded_mods) {
     if (auto* loaded_mod = std::get_if<LoadedMod>(&m)) {
@@ -272,7 +275,8 @@ void load_mods() noexcept {
 
   for (auto& m : loaded_mods) {
     if (auto* loaded_mod = std::get_if<LoadedMod>(&m)) {
-      LOG_DEBUG("Attempting to call late_load on mod: {} {}", loaded_mod->object.path.c_str(), fmt::ptr(loaded_mod->late_loadFn.value_or(nullptr)));
+      LOG_DEBUG("Attempting to call late_load on mod: {} {}", loaded_mod->object.path.c_str(),
+                fmt::ptr(loaded_mod->late_loadFn.value_or(nullptr)));
       if (!loaded_mod->late_load()) {
         // Load call does not exist, but the mod was still loaded
         LOG_INFO("No late_load function on mod: {}", loaded_mod->object.path.c_str());


### PR DESCRIPTION
To improve header support for toolchains that don't include JNI, but are still ABI compatible with sl2 e.g Rust targetting aarch64-android, this stubs out the JavaVM pointer. As it is a pointer, the ABI compatibility is unaffected based on the macro conditions.