### PR TITLE
Unity 6 compatibility

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -201,7 +201,10 @@ uint32_t* find_unity_hook_loc([[maybe_unused]] void* unity_handle, void* il2cpp_
   }
 
   auto destroy_immediate = static_cast<uint32_t*>(resolve_icall("UnityEngine.Object::DestroyImmediate"));
-  RET_NULL_LOG_UNLESS(destroy_immediate);
+  if (!destroy_immediate) {
+    destroy_immediate = static_cast<uint32_t*>(resolve_icall("UnityEngine.Object::DestroyImmediate_Injected"));
+    RET_NULL_LOG_UNLESS(destroy_immediate);
+  }
   LOG_OFFSET("UnityEngine.Object::DestroyImmediate", destroy_immediate);
 
   // find first ret to find end of method

--- a/src/runtime-restriction.cpp
+++ b/src/runtime-restriction.cpp
@@ -10,7 +10,10 @@
 #include <unistd.h>
 #include <unordered_map>
 
-#define PAGE_START(addr) (PAGE_MASK & addr)
+static const int kPageSize = getpagesize();
+static const int kPageMask = ~(kPageSize - 1);
+
+#define PAGE_START(addr) (kPageMask & addr)
 
 namespace runtime_restriction {
 
@@ -94,7 +97,7 @@ bool init(std::string_view modloaderFile) {
       }
     }
     if (mainNamespace != nullptr) {
-      mprotect(reinterpret_cast<void*>(PAGE_START(reinterpret_cast<uintptr_t>(mainNamespace))), PAGE_SIZE,
+      mprotect(reinterpret_cast<void*>(PAGE_START(reinterpret_cast<uintptr_t>(mainNamespace))), kPageSize,
                PROT_READ | PROT_WRITE);
       mainNamespace->set_isolated(false);
     } else {


### PR DESCRIPTION
check for DestroyImmediate_Injected if DestroyImmediate isn't found